### PR TITLE
feat: c3x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,7 +55,6 @@
             "matchPackageNames": [
                 "helm/helm",
                 "open-policy-agent/conftest",
-                "infracost/infracost",
                 "sigstore/cosign",
                 "getsentry/sentry-cli",
                 "DaspawnW/vault-crd-helm-renderer",
@@ -144,18 +143,6 @@
                 ".*\\sCONFTEST_VERSION=(?<currentValue>\\d.*\\.?)"
             ],
             "depNameTemplate": "open-policy-agent/conftest",
-            "datasourceTemplate": "github-releases",
-            "extractVersionTemplate": "^v(?<version>.*)$"
-        },
-        {
-            "customType": "regex",
-            "fileMatch": [
-                ".*\\/Dockerfile"
-            ],
-            "matchStrings": [
-                ".*\\sINFRACOST_VERSION=(?<currentValue>\\d.*\\.?)"
-            ],
-            "depNameTemplate": "infracost/infracost",
             "datasourceTemplate": "github-releases",
             "extractVersionTemplate": "^v(?<version>.*)$"
         },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,7 +58,11 @@
                 "infracost/infracost",
                 "sigstore/cosign",
                 "getsentry/sentry-cli",
-                "DaspawnW/vault-crd-helm-renderer"
+                "DaspawnW/vault-crd-helm-renderer",
+                "kyverno/kyverno",
+                "c3xdev/c3x",
+                "kubernetes/kubernetes",
+                "tofuutils/tenv"
             ],
             "versioning": "semver"
         },
@@ -114,7 +118,7 @@
                 ".*\\/Dockerfile"
             ],
             "matchStrings": [
-                ".*\\sHELM_VERSION=(?<currentValue>v\\d.*\\.?)"
+                ".*\\sHELM_VERSION=(?<currentValue>\\d.*\\.?)"
             ],
             "depNameTemplate": "helm/helm",
             "datasourceTemplate": "github-releases",
@@ -208,10 +212,58 @@
                 ".*\\/Dockerfile"
             ],
             "matchStrings": [
+                ".*\\sKYVERNO_CLI_VERSION=(?<currentValue>\\d.*\\.?)"
+            ],
+            "depNameTemplate": "kyverno/kyverno",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.*)$"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                ".*\\/Dockerfile"
+            ],
+            "matchStrings": [
+                ".*\\sC3X_VERSION=(?<currentValue>\\d.*\\.?)"
+            ],
+            "depNameTemplate": "c3xdev/c3x",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.*)$"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                ".*\\/Dockerfile"
+            ],
+            "matchStrings": [
                 ".*\\sPIP_HVAC_VERSION=(?<currentValue>\\d.*\\.?)"
             ],
             "depNameTemplate": "hvac",
             "datasourceTemplate": "pypi"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                ".*\\/Dockerfile"
+            ],
+            "matchStrings": [
+                ".*\\sKUBECTL_VERSION=(?<currentValue>\\d.*\\.?)"
+            ],
+            "depNameTemplate": "kubernetes/kubernetes",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.*)$"
+        },
+        {
+            "customType": "regex",
+            "fileMatch": [
+                ".*\\/Dockerfile"
+            ],
+            "matchStrings": [
+                ".*\\sTENV_VERSION=(?<currentValue>\\d.*\\.?)"
+            ],
+            "depNameTemplate": "tofuutils/tenv",
+            "datasourceTemplate": "github-releases",
+            "extractVersionTemplate": "^v(?<version>.*)$"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Jenkins JNLP images with additional tooling.
 | kubectl | `1.34.6` |
 | Helm | `3.21.0` |
 | Ansible | `11.12.0` |
-| Infracost | `0.10.40` |
 | C3X | `1.0.1` |
 | Cosign | `2.6.2` |
 | Sentry CLI | `2.58.4` |

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # Docker images
-
 Jenkins JNLP images with additional tooling.
 
 ## Jenkins Inbound Agent
-
-INBOUND_AGENT_VERSION=jenkins/inbound-agent:alpine-jdk21
-VAULT_VERSION=1.21.2
-PACKER_VERSION=1.14.3
-TERRAFORM_1_VERSION=1.14.3
-KUBECTL_VERSION=1.33.6
-HELM_VERSION=3.19.2
-ANSIBLE_VERSION=11.12.0
-INFRACOST_VERSION=0.10.40
-COSIGN_VERSION=2.6.2
-SENTRY_CLI_VERSION=2.58.4
-CHECKOV_VERSION=3.2.497
-VAULT_CRD_RENDERER_VERSION=1.0.8
-PIP_HVAC_VERSION=2.4.0
-KYVERNO_CLI_VERSION=1.15.2
-NIXOS_CHANNEL=nixos-25.11
-TENV_VERSION=4.9.1
+| Tool | Version |
+|------|---------|
+| Base image | `jenkins/inbound-agent:alpine-jdk21` |
+| Vault | `1.21.2` |
+| Packer | `1.15.3` |
+| Terraform | `1.15.3` |
+| kubectl | `1.34.6` |
+| Helm | `3.21.0` |
+| Ansible | `11.12.0` |
+| Infracost | `0.10.40` |
+| C3X | `1.0.1` |
+| Cosign | `2.6.2` |
+| Sentry CLI | `2.58.4` |
+| Checkov | `3.2.528` |
+| Vault CRD Renderer | `1.0.8` |
+| hvac (pip) | `2.4.0` |
+| Kyverno CLI | `1.17.2` |
+| NixOS channel | `nixos-25.11` |
+| tenv | `4.12.2` |

--- a/jenkins-inbound-agent/Dockerfile
+++ b/jenkins-inbound-agent/Dockerfile
@@ -6,15 +6,16 @@ ARG VAULT_VERSION=1.21.2
 ARG PACKER_VERSION=1.15.3
 ARG TERRAFORM_1_VERSION=1.15.3
 ARG KUBECTL_VERSION=1.34.6
-ARG HELM_VERSION=v3.21.0
+ARG HELM_VERSION=3.21.0
 ARG ANSIBLE_VERSION=11.12.0
-ARG INFRACOST_VERSION=v0.10.40
+ARG INFRACOST_VERSION=0.10.40
+ARG C3X_VERSION=1.0.1
 ARG COSIGN_VERSION=2.6.2
 ARG SENTRY_CLI_VERSION=2.58.4
 ARG CHECKOV_VERSION=3.2.528
 ARG VAULT_CRD_RENDERER_VERSION=1.0.8
 ARG PIP_HVAC_VERSION=2.4.0
-ARG KYVERNO_CLI_VERSION=v1.17.2
+ARG KYVERNO_CLI_VERSION=1.17.2
 ARG NIXOS_CHANNEL=nixos-25.11
 ARG TENV_VERSION=4.12.2
 
@@ -54,38 +55,34 @@ RUN set -eux; \
   rm -rf /var/cache/apk/*
 
 RUN set -eux; \
-  ARCH="$(uname -m)"; \
+  ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"; \
   case "${ARCH}" in \
-  aarch64) \
+  arm64) \
   VAULT_DOWNLOAD_URL="https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_arm64.zip"; \
   PACKER_DOWNLOAD_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_arm64.zip"; \
   KUBECTL_DOWNLOAD_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/arm64/kubectl"; \
-  HELM_DOWNLOAD_URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-arm64.tar.gz"; \
-  HELM_FOLDER="linux-arm64"; \
-  INFRACOST_DOWNLOAD_FILE="infracost-linux-arm64"; \
-  INFRACOST_ARCH="arm64"; \
-  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/${INFRACOST_VERSION}"; \
+  HELM_DOWNLOAD_URL="https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz"; \
+  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}"; \
+  C3X_DOWNLOAD_URL="https://github.com/c3xdev/c3x/releases/download/v${C3X_VERSION}"; \
   COSIGN_DOWNLOAD_URL="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-arm64"; \
   SENTRY_DOWNLOAD_URL="https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}?response=download&arch=aarch64&platform=Linux&package=sentry-cli"; \
   SENTRY_HASHSUM=$(curl "https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}" | jq -r '.files."sentry-cli-Linux-aarch64".checksums."sha256-hex"');\
   VAULT_CRD_RENDERER_URL="https://github.com/DaspawnW/vault-crd-helm-renderer/releases/download/v${VAULT_CRD_RENDERER_VERSION}"; \
-  KYVERNO_CLI_DOWNLOAD_URL="https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_arm64.tar.gz"; \
+  KYVERNO_CLI_DOWNLOAD_URL="https://github.com/kyverno/kyverno/releases/download/v${KYVERNO_CLI_VERSION}/kyverno-cli_v${KYVERNO_CLI_VERSION}_linux_arm64.tar.gz"; \
   TENV_DOWNLOAD_URL="https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_Linux_arm64.tar.gz" \
   ;; \
-  x86_64) \
+  amd64) \
   VAULT_DOWNLOAD_URL="https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip"; \
   PACKER_DOWNLOAD_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"; \
   KUBECTL_DOWNLOAD_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"; \
-  HELM_DOWNLOAD_URL="https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"; \
-  HELM_FOLDER="linux-amd64"; \
-  INFRACOST_DOWNLOAD_FILE="infracost-linux-amd64"; \
-  INFRACOST_ARCH="amd64"; \
-  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/${INFRACOST_VERSION}"; \
+  HELM_DOWNLOAD_URL="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"; \
+  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}"; \
+  C3X_DOWNLOAD_URL="https://github.com/c3xdev/c3x/releases/download/v${C3X_VERSION}"; \
   COSIGN_DOWNLOAD_URL="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64"; \
   SENTRY_DOWNLOAD_URL="https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}?response=download&arch=x86_64&platform=Linux&package=sentry-cli"; \
   SENTRY_HASHSUM=$(curl "https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}" | jq -r '.files."sentry-cli-Linux-x86_64".checksums."sha256-hex"');\
   VAULT_CRD_RENDERER_URL="https://github.com/DaspawnW/vault-crd-helm-renderer/releases/download/v${VAULT_CRD_RENDERER_VERSION}"; \
-  KYVERNO_CLI_DOWNLOAD_URL="https://github.com/kyverno/kyverno/releases/download/${KYVERNO_CLI_VERSION}/kyverno-cli_${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz"; \
+  KYVERNO_CLI_DOWNLOAD_URL="https://github.com/kyverno/kyverno/releases/download/v${KYVERNO_CLI_VERSION}/kyverno-cli_v${KYVERNO_CLI_VERSION}_linux_x86_64.tar.gz" \
   TENV_DOWNLOAD_URL="https://github.com/tofuutils/tenv/releases/download/v${TENV_VERSION}/tenv_v${TENV_VERSION}_Linux_x86_64.tar.gz" \
   ;; \
   *) \
@@ -93,7 +90,7 @@ RUN set -eux; \
   exit 1; \
   ;; \
   esac; \
-  #### install boto3, checov, ansible, hvac and pre-commit
+  #### install boto3, checkov, ansible, hvac and pre-commit
   pip3 install --no-cache-dir -U boto3 checkov==${CHECKOV_VERSION} ansible==${ANSIBLE_VERSION} hvac==${PIP_HVAC_VERSION} pre-commit jc; \
   #### install vault
   _vault_tmp_dir=$(mktemp -d) && cd "${_vault_tmp_dir}"; \
@@ -109,25 +106,33 @@ RUN set -eux; \
   curl -L "${KUBECTL_DOWNLOAD_URL}" -o "kubectl"; \
   chmod +x kubectl && mv kubectl /usr/bin; \
   #### install helm
+  HELM_FOLDER="linux-${ARCH}"; \
   _helm_tmp_dir=$(mktemp -d) && cd "${_helm_tmp_dir}"; \
   curl -L "${HELM_DOWNLOAD_URL}" -o "${_helm_tmp_dir}/helm.tar.gz"; \
   tar -xvzf "${_helm_tmp_dir}/helm.tar.gz" && chmod +x "${_helm_tmp_dir}/${HELM_FOLDER}/helm" && mv "${_helm_tmp_dir}/${HELM_FOLDER}/helm" /usr/bin; \
   cd && rm -rf "${_helm_tmp_dir}"; \
   #### install infracost
+  INFRACOST_DOWNLOAD_FILE="infracost-linux-${ARCH}"; \
   curl -L "${INFRACOST_DOWNLOAD_URL}/${INFRACOST_DOWNLOAD_FILE}.tar.gz" -o "${INFRACOST_DOWNLOAD_FILE}.tar.gz"; \
   curl -L "${INFRACOST_DOWNLOAD_URL}/${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256" -o "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
   sha256sum -c "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
   mkdir /opt/infracost_bin; \
   tar xf "${INFRACOST_DOWNLOAD_FILE}.tar.gz" -C /opt/infracost_bin/; \
   rm "${INFRACOST_DOWNLOAD_FILE}.tar.gz" "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
-  case "$(uname -m)" in \
-  x86_64) arch="amd64" ;; \
-  aarch64) arch="arm64" ;; \
-  *) echo "Unsupported architecture: $(uname -m)" && exit 1 ;; \
-  esac; \
-  chmod +x "/opt/infracost_bin/infracost-linux-${arch}"; \
-  mv "/opt/infracost_bin/infracost-linux-${arch}" /opt/infracost_bin/infracost; \
+  chmod +x "/opt/infracost_bin/${INFRACOST_DOWNLOAD_FILE}"; \
+  mv "/opt/infracost_bin/${INFRACOST_DOWNLOAD_FILE}" /opt/infracost_bin/infracost; \
   ln -s /opt/infracost_bin/infracost /usr/local/bin/infracost; \
+  #### install c3x
+  C3X_DOWNLOAD_FILE="c3x-linux-${ARCH}"; \
+  curl -L "${C3X_DOWNLOAD_URL}/${C3X_DOWNLOAD_FILE}.tar.gz" -o "${C3X_DOWNLOAD_FILE}.tar.gz"; \
+  curl -L "${C3X_DOWNLOAD_URL}/${C3X_DOWNLOAD_FILE}.tar.gz.sha256" -o "${C3X_DOWNLOAD_FILE}.tar.gz.sha256"; \
+  sha256sum -c "${C3X_DOWNLOAD_FILE}.tar.gz.sha256"; \
+  mkdir /opt/c3x_bin; \
+  tar xf "${C3X_DOWNLOAD_FILE}.tar.gz" -C /opt/c3x_bin/; \
+  rm "${C3X_DOWNLOAD_FILE}.tar.gz" "${C3X_DOWNLOAD_FILE}.tar.gz.sha256"; \
+  chmod +x "/opt/c3x_bin/${C3X_DOWNLOAD_FILE}"; \
+  mv "/opt/c3x_bin/${C3X_DOWNLOAD_FILE}" /opt/c3x_bin/c3x; \
+  ln -s /opt/c3x_bin/c3x /usr/local/bin/c3x; \
   #### install sentry-cli
   curl -L "${SENTRY_DOWNLOAD_URL}" -o sentry-cli; \
   echo "${SENTRY_HASHSUM}  sentry-cli" | sha256sum -c; \
@@ -186,6 +191,7 @@ RUN kubectl version --client && \
   packer version && \
   vault version && \
   infracost --version && \
+  c3x --version && \
   cosign version && \
   sentry-cli --version && \
   kyverno version && \

--- a/jenkins-inbound-agent/Dockerfile
+++ b/jenkins-inbound-agent/Dockerfile
@@ -8,7 +8,6 @@ ARG TERRAFORM_1_VERSION=1.15.3
 ARG KUBECTL_VERSION=1.34.6
 ARG HELM_VERSION=3.21.0
 ARG ANSIBLE_VERSION=11.12.0
-ARG INFRACOST_VERSION=0.10.40
 ARG C3X_VERSION=1.0.1
 ARG COSIGN_VERSION=2.6.2
 ARG SENTRY_CLI_VERSION=2.58.4
@@ -62,7 +61,6 @@ RUN set -eux; \
   PACKER_DOWNLOAD_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_arm64.zip"; \
   KUBECTL_DOWNLOAD_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/arm64/kubectl"; \
   HELM_DOWNLOAD_URL="https://get.helm.sh/helm-v${HELM_VERSION}-linux-arm64.tar.gz"; \
-  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}"; \
   C3X_DOWNLOAD_URL="https://github.com/c3xdev/c3x/releases/download/v${C3X_VERSION}"; \
   COSIGN_DOWNLOAD_URL="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-arm64"; \
   SENTRY_DOWNLOAD_URL="https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}?response=download&arch=aarch64&platform=Linux&package=sentry-cli"; \
@@ -76,7 +74,6 @@ RUN set -eux; \
   PACKER_DOWNLOAD_URL="https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip"; \
   KUBECTL_DOWNLOAD_URL="https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"; \
   HELM_DOWNLOAD_URL="https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz"; \
-  INFRACOST_DOWNLOAD_URL="https://github.com/infracost/infracost/releases/download/v${INFRACOST_VERSION}"; \
   C3X_DOWNLOAD_URL="https://github.com/c3xdev/c3x/releases/download/v${C3X_VERSION}"; \
   COSIGN_DOWNLOAD_URL="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64"; \
   SENTRY_DOWNLOAD_URL="https://release-registry.services.sentry.io/apps/sentry-cli/${SENTRY_CLI_VERSION}?response=download&arch=x86_64&platform=Linux&package=sentry-cli"; \
@@ -111,17 +108,6 @@ RUN set -eux; \
   curl -L "${HELM_DOWNLOAD_URL}" -o "${_helm_tmp_dir}/helm.tar.gz"; \
   tar -xvzf "${_helm_tmp_dir}/helm.tar.gz" && chmod +x "${_helm_tmp_dir}/${HELM_FOLDER}/helm" && mv "${_helm_tmp_dir}/${HELM_FOLDER}/helm" /usr/bin; \
   cd && rm -rf "${_helm_tmp_dir}"; \
-  #### install infracost
-  INFRACOST_DOWNLOAD_FILE="infracost-linux-${ARCH}"; \
-  curl -L "${INFRACOST_DOWNLOAD_URL}/${INFRACOST_DOWNLOAD_FILE}.tar.gz" -o "${INFRACOST_DOWNLOAD_FILE}.tar.gz"; \
-  curl -L "${INFRACOST_DOWNLOAD_URL}/${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256" -o "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
-  sha256sum -c "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
-  mkdir /opt/infracost_bin; \
-  tar xf "${INFRACOST_DOWNLOAD_FILE}.tar.gz" -C /opt/infracost_bin/; \
-  rm "${INFRACOST_DOWNLOAD_FILE}.tar.gz" "${INFRACOST_DOWNLOAD_FILE}.tar.gz.sha256"; \
-  chmod +x "/opt/infracost_bin/${INFRACOST_DOWNLOAD_FILE}"; \
-  mv "/opt/infracost_bin/${INFRACOST_DOWNLOAD_FILE}" /opt/infracost_bin/infracost; \
-  ln -s /opt/infracost_bin/infracost /usr/local/bin/infracost; \
   #### install c3x
   C3X_DOWNLOAD_FILE="c3x-linux-${ARCH}"; \
   curl -L "${C3X_DOWNLOAD_URL}/${C3X_DOWNLOAD_FILE}.tar.gz" -o "${C3X_DOWNLOAD_FILE}.tar.gz"; \
@@ -190,7 +176,6 @@ RUN kubectl version --client && \
   helm version && \
   packer version && \
   vault version && \
-  infracost --version && \
   c3x --version && \
   cosign version && \
   sentry-cli --version && \


### PR DESCRIPTION
## Summary

Replace infracost with c3x and improve tool version management in the jenkins-inbound-agent image.

## Changes

- **Replace infracost with c3x**: Removed infracost and installed c3x (v1.0.1) from c3xdev/c3x with sha256 checksum verification
- **Fix version string handling**: Removed v prefix from ARG values for HELM_VERSION and KYVERNO_CLI_VERSION - prefix is now added at URL construction time
- **Simplify arch detection**: Normalized uname -m output to amd64/arm64 upfront, eliminating duplicated mapping logic in each arch block
- **Renovate config**: Removed infracost; added regex extractors for C3X_VERSION, KYVERNO_CLI_VERSION, KUBECTL_VERSION, TENV_VERSION; added c3xdev/c3x, kyverno/kyverno, kubernetes/kubernetes and tofuutils/tenv to semver package list; fixed Helm version regex for non-v-prefixed values
- **README**: Reformatted tool versions as a Markdown table and updated to latest versions